### PR TITLE
🐛 Fix log message on transfer to mobile if amount insufficient

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,8 +95,13 @@ vorpal
     promise.then(async (inputs) => {
       const { amount, msisdn, purpose } = inputs
       try {
-        const resp = await sendToMobile(amount, msisdn, purpose, user, authCode)
-        this.log(`${resp.data.transactionId} Confirmed, Ksh ${amount} has been transfered to ${msisdn}. Purpose: ${purpose}`)
+        const resp = await sendToMobile(amount, msisdn, purpose, user, authCode);
+        
+        if(resp.data && resp.data.balanceAfterTxn === -1){
+          this.log("Oops! You don't seem to have that much in your account.");
+        } else {
+          this.log(`${resp.data.transactionId} Confirmed, Ksh ${amount} has been transfered to ${msisdn}. Purpose: ${purpose}`);
+        }
       } catch (e) {
         this.log(`Transfer Failed. Reason: ${e.message}`)
       }


### PR DESCRIPTION
Just opened a new  loop account and tested the CLI.

Tried transferring  10 KSh to mobile with my account having 0 balance

Actual Log Message

> "Confirmed, Ksh 10 has been transfered to <phonenumber> ...."

Expected Log message to be

> "Oops! You don't seem to have that much in your account.